### PR TITLE
[feature #5]: Added support for ROOT_PATH

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -eo pipefail  # stronger error handling than just 'set -e'
 
+# NOTE: ROOT_PATH needs to be defined before supervisord can pass it to
+#   our app (if necessary)
+export ROOT_PATH="$ROOT_PATH"
+
 # start services and record the PID
 supervisord -c /etc/supervisor/supervisord.conf &
 supervisord_pid=$!

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -6,6 +6,7 @@
 
 import logging
 import logging.config
+import os
 from contextlib import asynccontextmanager
 from typing import AsyncGenerator
 
@@ -77,9 +78,14 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     logger.info("Lifespan ended")
 
 
+# NOTE: ROOT_PATH is the equivalent of "SCRIPT_NAME" in WSGI, and specifies
+#   a prefix that should be removed from  from route evaluation
+root_path = os.getenv("ROOT_PATH", "")
+print(f"Starting app with root_path='{root_path}'")
+
 # Initialize FastAPI application and middleware
 # NOTE: duration middleware must be first to log req IDs correctly
-app: FastAPI = FastAPI(lifespan=lifespan)
+app: FastAPI = FastAPI(lifespan=lifespan, root_path=root_path)
 app.add_middleware(RequestDurationMiddleware)
 app.add_middleware(RequestIDMiddleware)
 app.add_middleware(


### PR DESCRIPTION
ROOT_PATH allows the app to be work behind a proxy. See https://fastapi.tiangolo.com/advanced/behind-a-proxy/ for more details.