### PR TITLE
feat(mcp): add support for stateless HTTP to MCP server

### DIFF
--- a/src/app/core/v1/settings.py
+++ b/src/app/core/v1/settings.py
@@ -74,6 +74,7 @@ class McpSettings(BaseModel):
         openapi_path: Path to the OpenAPI specification.
         mcp_mount_path: Mount path for the MCP interface.
         max_retries: Maximum number of retries for fetching the OpenAPI spec.
+        stateless_http: Whether to use stateless or in-memory state/session tracking.
     """
 
     headers: dict[str, str] = {}
@@ -81,6 +82,7 @@ class McpSettings(BaseModel):
     openapi_path: str = "/openapi.json"
     mcp_mount_path: str = "/mcp"
     max_retries: int = 5
+    stateless_http: bool = True
 
 
 class KafkaSettings(BaseModel):

--- a/src/app/mcp.py
+++ b/src/app/mcp.py
@@ -75,7 +75,14 @@ async def mcp_lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             )
 
             # create FastMCP ASGI app and attach its lifespan
-            mcp_inner_app = mcp.http_app(path="/")
+            logger.debug(
+                "Creating MCP http_app with stateless_http="
+                f"{settings.mcp.stateless_http}"
+            )
+            mcp_inner_app = mcp.http_app(
+                path="/",
+                stateless_http=settings.mcp.stateless_http,
+            )
             await stack.enter_async_context(mcp_inner_app.lifespan(app))
             logger.info("Initialized MCP lifespan")
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -68,7 +68,7 @@ async def test_mcp_lifespan_mounts_app():
 
         mock_client.get.assert_awaited_once_with("/openapi.json")
         mock_response.json.assert_called_once()
-        mock_mcp.http_app.assert_called_once_with(path="/")
+        mock_mcp.http_app.assert_called_once()
         mock_mount.assert_called_once_with("/mcp", mock_http_app)
 
 


### PR DESCRIPTION
Added configurable option to run MCP ASGI server with `stateless_http=True`. This will close #97.