### PR TITLE
feat(api): app.add_exception_handler for AuthorizationError

### DIFF
--- a/src/app/errors/v1/exception_handlers.py
+++ b/src/app/errors/v1/exception_handlers.py
@@ -105,3 +105,20 @@ def upstream_api_exception_handler(request: Request, exc: Exception) -> JSONResp
             "request_id": exc.req_id,
         },
     )
+
+
+def authorization_error_handler(request: Request, exc: Exception) -> JSONResponse:
+    """
+    Handle AuthorizationError exceptions.
+
+    Args:
+        request: The incoming HTTP request.
+        exc: The raised IndexError exception.
+
+    Returns:
+        JSONResponse: A 403 response indicating an authorization failure.
+    """
+    return JSONResponse(
+        status_code=403,
+        content={"message": f"{exc}"},
+    )

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -14,6 +14,7 @@ import toml  # NOTE: support backwards compatibility <= Python 3.11
 from fastapi import FastAPI, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.utils import get_openapi
+from nmtfast.auth.v1.exceptions import AuthorizationError
 from nmtfast.errors.v1.exceptions import UpstreamApiException
 from nmtfast.logging.v1.config import create_logging_config
 from nmtfast.middleware.v1.request_duration import RequestDurationMiddleware
@@ -25,6 +26,7 @@ from app.core.v1.kafka import create_kafka_consumers, create_kafka_producer
 from app.core.v1.settings import AppSettings, get_app_settings
 from app.core.v1.sqlalchemy import Base, async_engine
 from app.errors.v1.exception_handlers import (
+    authorization_error_handler,
     generic_not_found_error_handler,
     index_out_of_range_error_handler,
     resource_not_found_error_handler,
@@ -150,6 +152,10 @@ def register_exception_handlers() -> None:
     app.add_exception_handler(
         UpstreamApiException,
         upstream_api_exception_handler,
+    )
+    app.add_exception_handler(
+        AuthorizationError,
+        authorization_error_handler,
     )
 
 

--- a/src/app/services/v1/gadgets.py
+++ b/src/app/services/v1/gadgets.py
@@ -7,7 +7,6 @@
 import logging
 
 from nmtfast.auth.v1.acl import check_acl
-from nmtfast.auth.v1.exceptions import AuthorizationError
 from nmtfast.cache.v1.base import AppCacheBase
 from nmtfast.middleware.v1.request_id import REQUEST_ID_CONTEXTVAR
 from nmtfast.tasks.v1.huey import (
@@ -61,12 +60,9 @@ class GadgetService:
         Args:
             acls: List of ACLs associated with this client
             permission: Required in order to complete the requested operation.
-
-        Raises:
-            AuthorizationError: API key / OAuth client is not authorized.
         """
-        if not await check_acl("gadgets", acls, permission):
-            raise AuthorizationError(f"Not authorized to '{permission}'")
+        # NOTE: by default, check_acl now raises AuthorizationError on failure
+        await check_acl("gadgets", acls, permission)
 
     async def gadget_create(self, input_gadget: GadgetCreate) -> GadgetRead:
         """

--- a/src/app/services/v1/upstream.py
+++ b/src/app/services/v1/upstream.py
@@ -7,7 +7,6 @@
 import logging
 
 from nmtfast.auth.v1.acl import check_acl
-from nmtfast.auth.v1.exceptions import AuthorizationError
 from nmtfast.cache.v1.base import AppCacheBase
 from nmtfast.errors.v1.exceptions import UpstreamApiException
 from nmtfast.repositories.widgets.v1.api import WidgetApiRepository
@@ -54,12 +53,9 @@ class WidgetApiService:
         Args:
             acls: List of ACLs associated with this client
             permission: Required in order to complete the requested operation.
-
-        Raises:
-            AuthorizationError: API key / OAuth client is not authorized.
         """
-        if not await check_acl("widgets", acls, permission):
-            raise AuthorizationError(f"Not authorized to '{permission}'")
+        # NOTE: by default, check_acl now raises AuthorizationError on failure
+        await check_acl("widgets", acls, permission)
 
     async def widget_create(self, input_widget: WidgetCreate) -> WidgetRead:
         """

--- a/src/app/services/v1/widgets.py
+++ b/src/app/services/v1/widgets.py
@@ -9,7 +9,6 @@ from typing import Optional
 
 from aiokafka import AIOKafkaProducer
 from nmtfast.auth.v1.acl import check_acl
-from nmtfast.auth.v1.exceptions import AuthorizationError
 from nmtfast.cache.v1.base import AppCacheBase
 from nmtfast.middleware.v1.request_id import REQUEST_ID_CONTEXTVAR
 from nmtfast.tasks.v1.huey import (
@@ -66,12 +65,9 @@ class WidgetService:
         Args:
             acls: List of ACLs associated with this client
             permission: Required in order to complete the requested operation.
-
-        Raises:
-            AuthorizationError: API key / OAuth client is not authorized.
         """
-        if not await check_acl("widgets", acls, permission):
-            raise AuthorizationError(f"Not authorized to '{permission}'")
+        # NOTE: by default, check_acl now raises AuthorizationError on failure
+        await check_acl("widgets", acls, permission)
 
     async def widget_create(self, input_widget: WidgetCreate) -> WidgetRead:
         """

--- a/tests/errors/v1/test_exception_handlers.py
+++ b/tests/errors/v1/test_exception_handlers.py
@@ -9,12 +9,14 @@ from unittest.mock import MagicMock
 
 from fastapi import HTTPException, Request
 from fastapi.responses import JSONResponse
+from nmtfast.auth.v1.exceptions import AuthorizationError
 from nmtfast.errors.v1.exceptions import (
     BaseUpstreamRepositoryException,
     UpstreamApiException,
 )
 
 from app.errors.v1.exception_handlers import (
+    authorization_error_handler,
     generic_not_found_error_handler,
     index_out_of_range_error_handler,
     resource_not_found_error_handler,
@@ -101,3 +103,16 @@ def test_upstream_api_exception_handler():
         "message": "Service unavailable",
         "request_id": "req-123",
     }
+
+
+def test_authorization_error_handler():
+    """
+    Test AuthorizationError handler.
+    """
+    request = MagicMock(spec=Request)
+    exc = AuthorizationError("Test authorization error")
+    response = authorization_error_handler(request, exc)
+
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 403
+    assert json.loads(response.body) == {"message": "Test authorization error"}


### PR DESCRIPTION
Add app-wide handler for `AuthorizationError` in main.py. This will catch authorization failures and report the ACL failure back to the caller instead of returning a generic 500 status.

Closes #101 