### PR TITLE
ci(github): update version bump workflow

### DIFF
--- a/.github/workflows/main-pr-closed.yml
+++ b/.github/workflows/main-pr-closed.yml
@@ -8,10 +8,11 @@ on:
 
 jobs:
   bump_version:
-    if: "!startsWith(github.event.head_commit.message, 'bump:')"
+    name: Bump version and create changelog with commitizen
+    # NOTE: not currently working on self-hosted
     #runs-on: self-hosted
     runs-on: ubuntu-latest
-    name: "Bump version and create changelog with commitizen"
+    if: ${{ !(github.event.head_commit && startsWith(github.event.head_commit.message, 'bump:')) }}
     permissions:
       contents: write
       pull-requests: read
@@ -30,8 +31,10 @@ jobs:
       - name: Print Version
         run: echo "Bumped to version ${{ steps.cz.outputs.version }}"
 
-  pre-commit-codecov:
+  codecov:
+    name: Upload coverage to Codecov
     runs-on: self-hosted
+    if: ${{ !(github.event.head_commit && startsWith(github.event.head_commit.message, 'bump:')) }}
     strategy:
       fail-fast: false
       matrix:

--- a/poetry.lock
+++ b/poetry.lock
@@ -3504,4 +3504,4 @@ dev = ["pytest", "setuptools"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "de09de740e0750f714d61e3e26aef5e6b3d8d621b6dcde6ca13fb0f73cec4030"
+content-hash = "224f211c757819333377b885384226fb032cc756d36200b93497ab8ee9d8c677"


### PR DESCRIPTION
Update the bump_version job to correctly apply tag and version after each PR.

Refs: #111