### PR TITLE
refactor: lazy loading for api_clients

### DIFF
--- a/src/app/core/v1/discovery.py
+++ b/src/app/core/v1/discovery.py
@@ -2,41 +2,12 @@
 # Copyright (c) 2025. All rights reserved.
 # Licensed under the MIT License. See LICENSE file in the project root for details.
 
-"""Core functions for provisioning discovered services."""
+"""Core state for provisioned discovered services."""
 
-import logging
+import asyncio
 
-from nmtfast.discovery.v1.clients import create_api_client
-from nmtfast.discovery.v1.exceptions import ServiceConnectionError
+api_clients: dict = {}
+api_clients_lock: asyncio.Lock = asyncio.Lock()
 
-from app.core.v1.cache import app_cache
-from app.core.v1.settings import get_app_settings
-
-logger = logging.getLogger(__name__)
-settings = get_app_settings()
-api_clients = {}  # this will be populated by create_api_clients()
-
-# NOTE: these are names of services defined discovery section of the app config
-required_clients = ["widgets"]
-
-
-async def create_api_clients() -> None:
-    """
-    Create all API clients when the app starts.
-    """
-    for client_name in required_clients:
-        try:
-            api_clients[client_name] = await create_api_client(
-                settings.auth,
-                settings.discovery,
-                client_name,
-                cache=app_cache,
-            )
-        except ServiceConnectionError as exc:
-            logger.critical(f"API client failure for {client_name} service: {exc}")
-            for service, client in api_clients.items():
-                logger.warning(f"Attempting to close {service} API client...")
-                await client.aclose()
-            raise
-
-    logger.info(f"Created {len(api_clients.keys())} API client(s)")
+# NOTE: these are names of services defined in the discovery section of the app config
+required_clients: list[str] = ["widgets"]

--- a/src/app/dependencies/v1/discovery.py
+++ b/src/app/dependencies/v1/discovery.py
@@ -7,23 +7,23 @@
 import logging
 
 from fastapi import Depends
+from nmtfast.discovery.v1.clients import create_api_client
 
-from app.core.v1.discovery import api_clients
+from app.core.v1.cache import app_cache
+from app.core.v1.discovery import api_clients, api_clients_lock, required_clients
 from app.core.v1.settings import AppSettings, get_app_settings
 
 logger = logging.getLogger(__name__)
-settings = get_app_settings()
 
 
 async def get_api_clients(
     settings: AppSettings = Depends(get_app_settings),
 ) -> dict:
     """
-    Provides a dictionary of async httpx clients.
+    Provides a dictionary of async httpx clients, creating them lazily on first use.
 
-    This returns httpx clients that can be used to communicate with an upstream
-    API. The clients will have been configured during application startup, and can be
-    acquired from this function during dependency injection.
+    Clients are created on demand when first requested rather than at application
+    startup. This prevents upstream service unavailability from blocking app startup.
 
     Args:
         settings: The application settings.
@@ -31,4 +31,18 @@ async def get_api_clients(
     Returns:
         dict: A dictionary of async httpx clients.
     """
+    for client_name in required_clients:
+        # NOTE: this is double-checked locking to avoid unnecessary locking after
+        #   clients are initialized
+        if client_name not in api_clients:
+            async with api_clients_lock:
+                if client_name not in api_clients:
+                    logger.info(f"Lazily creating API client for '{client_name}'...")
+                    api_clients[client_name] = await create_api_client(
+                        settings.auth,
+                        settings.discovery,
+                        client_name,
+                        cache=app_cache,
+                    )
+                    logger.info(f"API client for '{client_name}' created successfully")
     return api_clients

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -21,7 +21,6 @@ from nmtfast.logging.v1.config import create_logging_config
 from nmtfast.middleware.v1.request_duration import RequestDurationMiddleware
 from nmtfast.middleware.v1.request_id import RequestIDMiddleware
 
-from app.core.v1.discovery import create_api_clients
 from app.core.v1.health import set_app_not_ready, set_app_ready
 from app.core.v1.kafka import create_kafka_consumers, create_kafka_producer
 from app.core.v1.settings import AppSettings, get_app_settings
@@ -182,9 +181,6 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     """
     logger: logging.Logger = logging.getLogger(__name__)
     logger.info("Lifespan started")
-
-    logger.info("Initializing API Clients (if any)...")
-    await create_api_clients()
 
     async with async_engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)  # pragma: no cover

--- a/tests/core/v1/test_discovery.py
+++ b/tests/core/v1/test_discovery.py
@@ -2,119 +2,29 @@
 # Copyright (c) 2025. All rights reserved.
 # Licensed under the MIT License. See LICENSE file in the project root for details.
 
-"""Tests for service discovery provisioning."""
+"""Tests for core discovery state."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+import asyncio
 
-import httpx
-import pytest
-from nmtfast.cache.v1.base import AppCacheBase
-from nmtfast.discovery.v1.exceptions import ServiceConnectionError
-
-from app.core.v1.discovery import api_clients, create_api_clients
-from app.core.v1.settings import AppSettings
+from app.core.v1.discovery import api_clients, api_clients_lock, required_clients
 
 
-@pytest.fixture
-def mock_settings():
+def test_api_clients_is_dict():
     """
-    Fixture to create a mock AppSettings.
+    Test that api_clients is initialized as an empty dict.
     """
-    settings = MagicMock(spec=AppSettings)
-    settings.auth = "mock_auth"
-    settings.discovery = "mock_discovery"
-    return settings
+    assert isinstance(api_clients, dict)
 
 
-@pytest.fixture
-def mock_cache():
+def test_api_clients_lock_is_asyncio_lock():
     """
-    Fixture to create a mock app_cache.
+    Test that api_clients_lock is an asyncio.Lock.
     """
-    return AsyncMock(spec=AppCacheBase)
+    assert isinstance(api_clients_lock, asyncio.Lock)
 
 
-@pytest.fixture(autouse=True)
-def setup_teardown():
+def test_required_clients_contains_widgets():
     """
-    Clear api_clients before and after each test.
+    Test that required_clients includes the widgets service.
     """
-    api_clients.clear()
-    yield
-    api_clients.clear()
-
-
-@pytest.mark.asyncio
-async def test_create_api_clients_success(mock_settings, mock_cache):
-    """
-    Test successful client creation.
-    """
-    with (
-        patch("app.core.v1.discovery.get_app_settings", return_value=mock_settings),
-        patch("app.core.v1.discovery.app_cache", mock_cache),
-        patch(
-            "app.core.v1.discovery.create_api_client", new_callable=AsyncMock
-        ) as mock_create,
-    ):
-
-        mock_client = AsyncMock(httpx.AsyncClient)
-        mock_create.return_value = mock_client
-
-        await create_api_clients()
-
-        assert len(api_clients) == 1
-        assert "widgets" in api_clients
-        assert api_clients["widgets"] is mock_client
-
-
-@pytest.mark.asyncio
-async def test_create_api_clients_failure(mock_settings, mock_cache):
-    """
-    Test client creation failure.
-    """
-    with (
-        patch(
-            "app.core.v1.discovery.get_app_settings",
-            return_value=mock_settings,
-        ),
-        patch(
-            "app.core.v1.discovery.app_cache",
-            mock_cache,
-        ),
-        patch(
-            "app.core.v1.discovery.create_api_client",
-            side_effect=ServiceConnectionError,
-        ),
-    ):
-        with pytest.raises(ServiceConnectionError):
-            await create_api_clients()
-
-        assert not api_clients  # no clients stored on failure
-
-
-@pytest.mark.asyncio
-async def test_create_api_clients_cleanup_on_failure(mock_settings, mock_cache):
-    """
-    Test existing clients are closed on failure.
-    """
-    existing_client = AsyncMock()
-    api_clients["existing"] = existing_client
-
-    with (
-        patch(
-            "app.core.v1.discovery.get_app_settings",
-            return_value=mock_settings,
-        ),
-        patch(
-            "app.core.v1.discovery.app_cache",
-            mock_cache,
-        ),
-        patch(
-            "app.core.v1.discovery.create_api_client",
-            side_effect=ServiceConnectionError,
-        ),
-    ):
-        with pytest.raises(ServiceConnectionError):
-            await create_api_clients()
-
-        existing_client.aclose.assert_called_once()
+    assert "widgets" in required_clients

--- a/tests/dependencies/v1/test_discovery.py
+++ b/tests/dependencies/v1/test_discovery.py
@@ -2,43 +2,105 @@
 # Copyright (c) 2025. All rights reserved.
 # Licensed under the MIT License. See LICENSE file in the project root for details.
 
-"""Tests for API client dependencies."""
+"""Tests for API client dependencies with lazy initialization."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
+from nmtfast.discovery.v1.exceptions import ServiceConnectionError
 
+from app.core.v1.discovery import api_clients
 from app.core.v1.settings import AppSettings
 from app.dependencies.v1.discovery import get_api_clients
 
-# from fastapi import Depends
-
 
 @pytest.fixture
-def mock_clients():
+def mock_settings():
     """
-    Fixture providing mock API clients.
+    Fixture providing mock AppSettings.
     """
-    return {"service1": MagicMock(), "service2": MagicMock()}
+    settings = MagicMock(spec=AppSettings)
+    settings.auth = "mock_auth"
+    settings.discovery = "mock_discovery"
+    return settings
 
 
 @pytest.fixture(autouse=True)
-def patch_dependencies(mock_clients):
+def clear_api_clients():
     """
-    Patch all dependencies.
+    Clear api_clients before and after each test.
     """
-    with (
-        patch("app.dependencies.v1.discovery.api_clients", mock_clients),
-        patch("app.dependencies.v1.discovery.get_app_settings") as mock_settings,
-    ):
-        mock_settings.return_value = MagicMock(spec=AppSettings)
-        yield
+    api_clients.clear()
+    yield
+    api_clients.clear()
 
 
 @pytest.mark.asyncio
-async def test_get_api_clients_returns_clients(mock_clients):
+async def test_get_api_clients_creates_client_lazily(mock_settings):
     """
-    Test that get_api_clients returns the api_clients dict.
+    Test that get_api_clients lazily creates a client when not yet present.
     """
-    result = await get_api_clients()
-    assert result is mock_clients
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+
+    with (
+        patch(
+            "app.dependencies.v1.discovery.create_api_client",
+            new_callable=AsyncMock,
+            return_value=mock_client,
+        ) as mock_create,
+        patch(
+            "app.dependencies.v1.discovery.app_cache",
+            new_callable=AsyncMock,
+        ) as mock_cache,
+    ):
+        result = await get_api_clients(settings=mock_settings)
+
+        assert "widgets" in result
+        assert result["widgets"] is mock_client
+        mock_create.assert_awaited_once_with(
+            mock_settings.auth,
+            mock_settings.discovery,
+            "widgets",
+            cache=mock_cache,
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_api_clients_returns_existing_client(mock_settings):
+    """
+    Test that get_api_clients returns an existing client without recreating it.
+    """
+    existing_client = AsyncMock(spec=httpx.AsyncClient)
+    api_clients["widgets"] = existing_client
+
+    with patch(
+        "app.dependencies.v1.discovery.create_api_client",
+        new_callable=AsyncMock,
+    ) as mock_create:
+        result = await get_api_clients(settings=mock_settings)
+
+        assert result["widgets"] is existing_client
+        mock_create.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_api_clients_propagates_connection_error(mock_settings):
+    """
+    Test that ServiceConnectionError propagates to the caller.
+    """
+    with (
+        patch(
+            "app.dependencies.v1.discovery.create_api_client",
+            new_callable=AsyncMock,
+            side_effect=ServiceConnectionError("upstream down"),
+        ),
+        patch(
+            "app.dependencies.v1.discovery.app_cache",
+            new_callable=AsyncMock,
+        ),
+    ):
+        with pytest.raises(ServiceConnectionError):
+            await get_api_clients(settings=mock_settings)
+
+    assert "widgets" not in api_clients

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -133,10 +133,6 @@ async def test_lifespan() -> None:
             mock_create_all,
         ),
         patch(
-            "app.core.v1.discovery.required_clients",
-            new=[],
-        ),
-        patch(
             "app.main.create_kafka_consumers",
             return_value=[mock_consumer_task_1, mock_consumer_task_2],
         ),
@@ -165,7 +161,6 @@ async def test_lifespan_kafka_producer_none() -> None:
 
     with (
         patch.object(Base.metadata, "create_all", mock_create_all),
-        patch("app.core.v1.discovery.required_clients", new=[]),
         patch("app.main.create_kafka_consumers", return_value=[mock_consumer_task]),
         patch("app.main.create_kafka_producer", return_value=None),
     ):


### PR DESCRIPTION
Lazy load api_clients during dependency injection:
- Prevent upstream from stalling app startup
- Reduce complexity of unit tests

Refs: #137